### PR TITLE
Add simple support ticket Discord bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# Ticket-Bot
+# Ticket Bot
+
+A simple Discord bot that lets users create support ticket channels.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install discord.py
+   ```
+2. Set the bot token as an environment variable:
+   ```bash
+   export DISCORD_TOKEN="your-bot-token"
+   ```
+3. Run the bot:
+   ```bash
+   python bot.py
+   ```
+
+## Usage
+
+Use the `!ticket` command to create a new support channel. Provide an optional name to customize the channel:
+
+```
+!ticket            # creates a channel named 'support'
+!ticket billing    # creates a channel named 'billing'
+```
+
+The bot will respond with a mention to the created channel and open it for the requesting user.

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,36 @@
+import os
+import discord
+from discord.ext import commands
+
+TOKEN = os.getenv("DISCORD_TOKEN")
+
+intents = discord.Intents.default()
+intents.message_content = True
+intents.guilds = True
+intents.members = True
+
+bot = commands.Bot(command_prefix="!", intents=intents)
+
+@bot.event
+async def on_ready():
+    print(f"Logged in as {bot.user}")
+
+@bot.command(name="ticket")
+async def create_ticket(ctx, *, channel_name: str = "support"):
+    guild = ctx.guild
+    channel_name = channel_name.replace(" ", "-")
+    overwrites = {
+        guild.default_role: discord.PermissionOverwrite(read_messages=False),
+        ctx.author: discord.PermissionOverwrite(read_messages=True, send_messages=True),
+    }
+
+    existing = discord.utils.get(guild.channels, name=channel_name)
+    if existing:
+        await ctx.send(f"A channel named `{channel_name}` already exists.")
+        return
+
+    channel = await guild.create_text_channel(channel_name, overwrites=overwrites)
+    await channel.send(f"{ctx.author.mention} this is your support channel.")
+    await ctx.send(f"Created channel {channel.mention} for you.")
+
+bot.run(TOKEN)


### PR DESCRIPTION
## Summary
- implement `bot.py` with `!ticket` command to create support channels
- document setup and usage in README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_b_6896d07fd4188320babfad83c4e247e7